### PR TITLE
498 fix - trigger onWarning with empty yml

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,13 @@ class YamlValidatore {
       doc = yaml.load(data, {
         onWarning: onWarning
       });
+
+      // i.e empty yml file
+      if (!doc) {
+        onWarning('File is empty');
+
+        return null;
+      }
     }
     catch (error) {
       const findNumber = error.message.match(FIND_LINENUMBER);

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -415,3 +415,18 @@ tape('Calls onWarning if invalid yaml', (test) => {
   ));
 
 });
+
+tape('Calls onWarning if empty yaml', (test) => {
+  test.plan(1);
+
+  const onWarning = sinon.spy();
+
+  const validatorInstance = new Validator({
+    onWarning
+  });
+  validatorInstance.validate(['tests/fixtures/empty.yml']);
+
+  test.true(onWarning.calledOnceWithExactly(
+    'File is empty', 'tests/fixtures/empty.yml'
+  ));
+});


### PR DESCRIPTION
https://github.com/paazmaya/yaml-validator/issues/498

Not sure if this fully fixes the issue as it is still not logged if `writeJson` option is enabled

If we are happy with this change, do we want to put this fix in v4 too?