### PR TITLE
fix incorrect array type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,7 +44,7 @@ declare class YamlValidatore {
      * @param {array} files List of files that have been checked that they exist
      * @returns {void}
      */
-    validate(files: array): void;
+    validate(files: string[]): void;
     /**
      * Create a report out of this, but in reality also run.
      * @returns {number} 0 when no errors, the count of invalid files otherwise.


### PR DESCRIPTION
This package does not work with TypeScript as is.
TypeScript arrays are typed as `type[]` or `Array<T>` not `array` - this PR makes the correction.

